### PR TITLE
Updating links

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
           <div class="copy-group">
             <div class="copy-main">
               <p>
-                The <a href="flickr.com/commons">Flickr Commons</a> program was launched in 2008 and has become a unique collection of historical photography shared with the Flickr community by 114 cultural institutions around the world.
+                The <a href="https://www.flickr.com/commons">Flickr Commons</a> program was launched in 2008 and has become a unique collection of historical photography shared with the Flickr community by 114 cultural institutions around the world.
               </p>
 
               <p>
@@ -148,17 +148,17 @@
               <h4>Further reading</h4>
               <ul>
                 <li>
-                  <a href="https://www.google.com/url?q=https://docs.google.com/document/d/19eHlYDCJS2F4KH-Eml8mW9aVqP5WVOaKN_-5XFW4-wc/edit?usp%3Dsharing&sa=D&source=editors&ust=1632419933954000&usg=AOvVaw3QH9b4LHVFyi3tLjJYKBfT">
+                  <a href="https://docs.google.com/document/d/19eHlYDCJS2F4KH-Eml8mW9aVqP5WVOaKN_-5XFW4-wc">
                     Flickr Commons Revitalization: Research Report
                   </a> (Google doc)
                 </li>
                 <li>
-                  <a href="https://www.google.com/url?q=https://docs.google.com/document/d/1zm6HRq6ryDP1RKNHckUsGBwsn2sZaQsP_woxo4HTAws/edit?usp%3Dsharing&sa=D&source=editors&ust=1632419933955000&usg=AOvVaw1HwzQx5QUrMC8gwMYkWskp">
+                  <a href="https://docs.google.com/document/d/1zm6HRq6ryDP1RKNHckUsGBwsn2sZaQsP_woxo4HTAws">
                     Flickr Commons Revitalization: Strategy 2021–2023
                   </a> (Google doc)
                 </li>
                 <li>
-                  <a href="https://docs.google.com/presentation/d/1t_vousKMZrGXx3auoVVQkflibqY5En9c0bL1ihgK9bc/edit?usp=sharing">
+                  <a href="https://docs.google.com/presentation/d/1t_vousKMZrGXx3auoVVQkflibqY5En9c0bL1ihgK9bc">
                     Revitalizing the Flickr Commons Program: Very Long-Term Thinking About Keeping Digital, Cultural Heritage Safe
                   </a> (Google slides). 2021 Creative Commons Summit.
                 </li>


### PR DESCRIPTION
## Problem

I snooped and read the new site and spotted a broken link to [flickr.com/commons](https://flickr.com/commons).

## Solution

* Fixed the broken relative link to [flickr.com/commons](https://flickr.com/commons)
* Trimmed the Google docs links to not use the google.com redirect (now just direct links to the docs)

### Notes

* I am excite!